### PR TITLE
Move back to google's ngx-brotli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.16.1
-ENV NGX_BROTLI_COMMIT 8104036af9cff4b1d34f22d00ba857e2a93a243c 
+ENV NGX_BROTLI_COMMIT e505dce68acc190cc5a1e780a3b0275e39f160ca 
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
@@ -78,7 +78,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		cmake \
 	&& mkdir -p /usr/src \
 	&& cd /usr/src \
-	&& git clone --recursive https://github.com/eustas/ngx_brotli.git \
+	&& git clone --recursive https://github.com/google/ngx_brotli.git \
 	&& cd ngx_brotli \
 	&& git checkout -b $NGX_BROTLI_COMMIT $NGX_BROTLI_COMMIT \
 	&& cd .. \

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # What is this?
-This project is based on Alpine Linux, the official nginx image and an nginx module that provides static and dynamic brotli compression. Brotli is built by Google. Originally this image used Google's nginx brotli module, though as it is no longer maintained I switched to [eustas' fork](https://github.com/eustas/ngx_brotli).
+This project is based on Alpine Linux, the official nginx image and an nginx module that provides static and dynamic brotli compression. [Brotli](https://github.com/google/brotli) and the [nginx brotli module ](https://github.com/google/ngx_brotli) are built by Google.
 
 # How to use this image
-As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/eustas/ngx_brotli#configuration-directives)
+As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)


### PR DESCRIPTION
[eustas/ngx_brotli](https://github.com/eustas/ngx_brotli) has been archived and all changes have been merged back to [google/ngx_brotli](https://github.com/google/ngx_brotli). Therefore we should also move back to google's `ngx_brotli`.