### PR TITLE
Replaces `SIGTERM` with `SIGQUIT` for graceful termination of nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,6 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80 443
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Patches the image to use graceful termination in response to stop signals ([context](https://nginx.org/en/docs/control.html)).

fixes fholzer/docker-nginx-brotli#41 