### PR TITLE
添加压缩类型文件，否则 不会生效的

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,11 +24,24 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    keepalive_timeout  65;
+    # keepalive_timeout  65;
+
+    # gzip  on;
+    # brotli on;
+    # brotli_static on;
+
+    keepalive_timeout  300;
+    client_max_body_size 1024m;
 
     gzip  on;
+    gzip_static on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/x-font-ttf application/vnd.ms-fontobject application/font-woff;
+
     brotli on;
     brotli_static on;
+    brotli_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/x-font-ttf application/vnd.ms-fontobject application/font-woff;
+
+
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
添加对js，css，字体文件等的支持。
否则你只开启，而不添加类型文件的支持，这没法生效的呀？？